### PR TITLE
Introduce post_hook for filesystem storage

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -46,6 +46,8 @@ fileext = .vcf
 # Create the directory if it doesn't exist: `True` or `False`
 #create = True
 #encoding = utf-8
+# For each new / updated file f, invoke the following script with argument f:
+#post_hook = /usr/local/bin/post_process.sh
 
 [storage bob_contacts_remote]
 type = carddav
@@ -69,6 +71,8 @@ collections = private,work
 type = filesystem
 path = ~/.calendars/
 fileext = .ics
+# For each new / updated file f, invoke the following script with argument f:
+#post_hook = /usr/local/bin/post_process.sh
 
 [storage bob_calendar_remote]
 type = caldav

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -9,6 +9,7 @@
 '''
 
 import os
+import subprocess
 
 import pytest
 
@@ -62,3 +63,36 @@ class TestFilesystemStorage(StorageTests):
         s.upload(Item(u'UID:a/b/c'))
         item_file, = tmpdir.listdir()
         assert str(item_file).endswith('a_b_c.txt')
+
+    def test_post_hook_inactive(self, tmpdir, monkeypatch):
+
+        def check_call_mock(*args, **kwargs):
+            assert False
+
+        monkeypatch.setattr(subprocess, 'call', check_call_mock)
+
+        s = self.storage_class(str(tmpdir), '.txt', post_hook=None)
+        s.upload(Item(u'UID:a/b/c'))
+
+    def test_post_hook_active(self, tmpdir, monkeypatch):
+
+        class Boolean(object):
+            def __init__(self):
+                self.called = False
+
+            def set_called(self):
+                self.called = True
+
+        mock_called = Boolean()
+        exe = 'foo'
+
+        def check_call_mock(l, *args, **kwargs):
+            mock_called.called = True
+            assert len(l) == 2
+            assert l[0] == exe
+
+        monkeypatch.setattr(subprocess, 'call', check_call_mock)
+
+        s = self.storage_class(str(tmpdir), '.txt', post_hook=exe)
+        s.upload(Item(u'UID:a/b/c'))
+        assert mock_called.called


### PR DESCRIPTION
This pull request adds the possibility to invoke external programs on new / updated local files, e.g. to post-process ics files and remove certain alerts.

Example:

```
[storage bob_calendar_local]
type = filesystem
path = ~/.calendars/
fileext = .ics
post_hook = /usr/local/bin/remove_alerts.sh
```