### PR TITLE
Repair message for exception

### DIFF
--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -484,7 +484,7 @@ class DavStorage(Storage):
                 dav_logger.debug('New content: {!r}'.format(item2.raw))
                 raise exceptions.WrongEtagError(
                     'While requesting the etag for {!r}, '
-                    'the item content changed.'
+                    'the item content changed.'.format(href)
                 )
         return href, etag
 


### PR DESCRIPTION
The exception message contained `{!r}` but it was never fed to `format()`