### PR TITLE
ssl: use verify and verify_fingerprint

### DIFF
--- a/docs/ssl-tutorial.rst
+++ b/docs/ssl-tutorial.rst
@@ -16,9 +16,6 @@ To pin the certificate by SHA1- or MD5-fingerprint::
     ...
     verify_fingerprint = "94:FD:7A:CB:50:75:A4:69:82:0A:F8:23:DF:07:FC:69:3E:CD:90:CA"
 
-This disables :ref:`validation against root CAs <ssl-cas>`, since
-``verify_fingerprint`` is much stricter anyway.
-
 .. _ssl-cas:
 
 Custom root CAs

--- a/vdirsyncer/storage/http.py
+++ b/vdirsyncer/storage/http.py
@@ -52,7 +52,6 @@ def prepare_verify(verify, verify_fingerprint):
             raise exceptions.UserError('Invalid value for verify_fingerprint '
                                        '({}), must be a string or null.'
                                        .format(verify_fingerprint))
-        verify = False
     elif not verify:
         raise exceptions.UserError('verify = false is forbidden. Consider '
                                    'setting verify_fingerprint instead, which '

--- a/vdirsyncer/utils/http.py
+++ b/vdirsyncer/utils/http.py
@@ -69,7 +69,6 @@ def request(method, url, session=None, latin1_fallback=True,
             raise RuntimeError('`verify_fingerprint` can only be used with '
                                'requests versions >= 2.4.1')
         _install_fingerprint_adapter(session, verify_fingerprint)
-        kwargs['verify'] = False
 
     func = session.request
 


### PR DESCRIPTION
Both have their uses. The latter is very strict in what it will accept,
but it does not catch expired certificates.

---
Addresses #245 without an option; set both, get both.