### PR TITLE
Use older lxml because of Travis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'click-log',
         'click-threading',
         'requests',
-        'lxml>=3.0',
+        'lxml >=3.0, <=3.4.4',
         # https://github.com/sigmavirus24/requests-toolbelt/pull/28
         'requests_toolbelt>=0.5.0',
         'atomicwrites'


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/5130

Meta: https://github.com/untitaker/vdirsyncer/issues/298