### PR TITLE
Fix typo on collection discovery doc

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -126,7 +126,7 @@ by automatically downloading a list of the configured user's collections::
     [pair my_contacts]
     a = my_contacts_local
     b = my_contacts_remote
-    collections = from b
+    collections = ["from b"]
 
     [storage my_contacts_local]
     type = filesystem


### PR DESCRIPTION
(the example from the doc crashes on setting validation)