### PR TITLE
Allow running deterministic tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ export RADICALE_BACKEND := filesystem
 export REQUIREMENTS := release
 export TESTSERVER_BASE := ./tests/storage/servers/
 export TRAVIS := false
+export CI := false
+export DETERMINISTIC_TESTS := false
 
 install-servers:
 	set -ex; \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,11 @@
 General-purpose fixtures for vdirsyncer's testsuite.
 '''
 import logging
+import os
 
 import click_log
-
 import pytest
+from hypothesis import settings, Verbosity
 
 
 @pytest.fixture(autouse=True)
@@ -27,3 +28,16 @@ except ImportError:
         return lambda x: x()
 else:
     del pytest_benchmark
+
+settings.register_profile("ci", settings(
+    max_examples=1000,
+    verbosity=Verbosity.verbose,
+))
+settings.register_profile("deterministic", settings(
+    derandomize=True,
+))
+
+if os.getenv('DETERMINISTIC_TESTS').lower == 'true':
+    settings.load_profile("deterministic")
+elif os.getenv('CI').lower == 'true':
+    settings.load_profile("ci")


### PR DESCRIPTION
Make tests deterministic when the `DETERMINISTIC_TESTS` environment variable is set to true. This satisfies requirements of downstream packagers which require deterministic tests.

Also run larger test samples when running on CI, in hope that at some point it might trigger a new edge case.

See #352
Would probably require an update to #354