### PR TITLE
Remove pytest-xprocess from test requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,3 @@ hypothesis>=3
 pytest
 pytest-localserver
 pytest-subtesthack
-pytest-xprocess


### PR DESCRIPTION
It is only required by ownCloud and Baikal testservers.